### PR TITLE
Include D3D12 Memory Allocator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = Dependency/CrossWindow-Graphics
 	url = https://github.com/alaingalvan/CrossWindow-Graphics.git
 	branch = master
+[submodule "Dependency/D3D12MemoryAllocator"]
+	path = Dependency/D3D12MemoryAllocator
+	url = https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,3 +27,7 @@ target_link_libraries(
     CrossWindowGraphics
 )
 target_include_directories(DX12Renderer PUBLIC "${CMAKE_SOURCE_DIR}/Dependency/CrossWindow-Graphics/src")
+
+add_subdirectory(Dependency/D3D12MemoryAllocator)
+target_link_libraries(DX12Renderer D3D12MemoryAllocator)
+target_include_directories(DX12Renderer PUBLIC "${CMAKE_SOURCE_DIR}/Dependency/D3D12MemoryAllocator/include")

--- a/src/Render/Renderer.cpp
+++ b/src/Render/Renderer.cpp
@@ -7,6 +7,7 @@
 #include "RendererUtils.h"
 #include "CrossWindow/Graphics.h"
 #include "../Math.h"
+#include "D3D12MemAlloc.h"
 
 
 namespace fs = std::filesystem;


### PR DESCRIPTION
D3D12 Memory Allocator is added as submodule and CMake links it to the project.
[DH-1](https://turanlibraries.atlassian.net/browse/DH-1?atlOrigin=eyJpIjoiZmNkZjRhOWUzOWNiNDc2YjkxNTM0MjE0ZjE4MTFiNWMiLCJwIjoiaiJ9)